### PR TITLE
Feature/update Github CI to run tests on release branches

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -2,9 +2,9 @@ name: Djangoplicity Customsearch CI
 
 on:
   push:
-    branches: [ master, develop ]
+    branches: [ master, develop, release/* ]
   pull_request:
-    branches: [ master, develop ]
+    branches: [ master, develop, release/* ]
 
 jobs:
   build:


### PR DESCRIPTION
This change is required to run tests in branches that are based on release/*