### PR TITLE
Upgrade/remove include from urls

### DIFF
--- a/requirements/requirements-essential.txt
+++ b/requirements/requirements-essential.txt
@@ -1,4 +1,4 @@
-Django==1.11.21
+Django==2.2
 setuptools
 xlwt
 

--- a/requirements/requirements-essential.txt
+++ b/requirements/requirements-essential.txt
@@ -1,4 +1,4 @@
-Django==2.2
+Django==1.11.21
 setuptools
 xlwt
 

--- a/test_project/urls.py
+++ b/test_project/urls.py
@@ -18,5 +18,5 @@ from django.conf.urls import url, include
 from test_project.admin import admin_site
 
 urlpatterns = [
-    url(r'^admin/', include(admin_site.urls)),
+    url(r'^admin/', admin_site.urls),
 ]


### PR DESCRIPTION
Fix issue: RemovedInDjango20Warning: Passing a 3-tuple to django.conf.urls.include() is deprecated. Pass a 2-tuple containing the list of patterns and app_name, and provide the namespace argument to include() instead.